### PR TITLE
Change in RunnableRequestHandler.run

### DIFF
--- a/src/proteomicsdb/org/requesttool/model/request/RunnableRequestHandler.java
+++ b/src/proteomicsdb/org/requesttool/model/request/RunnableRequestHandler.java
@@ -61,6 +61,8 @@ public class RunnableRequestHandler extends RequestHandler implements Runnable{
     @Override
     public void run(){
         this.data = this.request();
-        this.changeState(RequestEvent.READY_TO_WRITE);   
+        if(this.data!=null){
+            this.changeState(RequestEvent.READY_TO_WRITE);
+        }
     }
 }


### PR DESCRIPTION
These changes fix the issue of displaying the wrong error. 
In the earlier implementation the writing was started even when an error occured, thus always generating a writing error, because after an error in the request, the result is always null.

By now checking that the result is not null before starting the writing, it is ensured that the request was succesful. If there was an error, it will displayed and not overwritten by a writing error.
